### PR TITLE
Add a background around the post container

### DIFF
--- a/forum/Themes/Redsy/css/index.css
+++ b/forum/Themes/Redsy/css/index.css
@@ -1807,6 +1807,8 @@ div#pollmoderation
 #forumposts
 {
 	clear: both;
+	background-color: #EEE;
+	padding: 1em;
 }
 #forumposts .cat_bar
 {


### PR DESCRIPTION
This CSS change adds a background to the post container, making the animated background image on the shitpost board have the same appearance in posts as it does on the main board page. Instead of the background going across the whole page, it's only around the borders.