### PR TITLE
Fixes issue #59

### DIFF
--- a/forum/Themes/Redsy/css/index.css
+++ b/forum/Themes/Redsy/css/index.css
@@ -297,6 +297,12 @@ blockquote.bbc_standard_quote, blockquote.bbc_alternate_quote
 	overflow: auto;
 }
 
+/* Images in quotes */
+blockquote img {
+	max-height: 100px;
+	max-width: 200px;
+}
+
 /* Alterate blockquote stylings */
 blockquote.bbc_standard_quote
 {


### PR DESCRIPTION
Instead of hiding images in quotes entirely, I added some CSS to make them smaller. Now quoted images have a max height of 100px and a max width of 200px. This makes quoted images less obnoxious but you can still see the appropriate context of the post.