### PR TITLE
Add support for webm/mp4/ogg urls to video BBCode

### DIFF
--- a/forum/Sources/Subs.php
+++ b/forum/Sources/Subs.php
@@ -1626,7 +1626,13 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					}
 					else
 					{
-						$tag['content'] = "<a href='{$data}'>{$data}</a>";
+						$tag['content'] = "
+						<video width='768' height='auto' style='max-width: 100%' controls>
+						<source src='{$data}' type='video/mp4'>
+						<source src='{$data}' type='video/webm'>
+						<source src='{$data}' type='video/ogg'>
+						Your browser does not support the video tag.
+						</video>";
 					}
 
 					$data = $query['v'];


### PR DESCRIPTION
Super simple change, not sure why I didn't do this previously.