### PR TITLE
Add css to alternate board index colours

### DIFF
--- a/forum/Themes/Redsy/css/index.css
+++ b/forum/Themes/Redsy/css/index.css
@@ -4285,3 +4285,9 @@ ol.breadcrumb li:first-child, .breadcrumb li:last-child
 {
 	vertical-align: middle!important;
 }
+
+/* Alternating colours for posts */
+.table-striped > tbody > tr:nth-of-type(even) td:not(.stickybg)
+{
+    background-color: #f3f3f3;
+}


### PR DESCRIPTION
Adds alternating post colours to the board index:
![image](https://user-images.githubusercontent.com/2872995/84365197-017d8180-abc9-11ea-9322-2293ba26a99c.png)
